### PR TITLE
Faster rendering

### DIFF
--- a/liluat.lua
+++ b/liluat.lua
@@ -438,14 +438,16 @@ end
 -- @return string
 function liluat.render(t, env)
 	local result = {}
-	local co = coroutine.create(liluat.render_coroutine(t, env))
-	while coroutine.status(co) ~= 'dead' do
-		local ok, chunk = coroutine.resume(co)
-		if not ok then
-			error(chunk)
-		end
-		table.insert(result, chunk)
-	end
+
+	-- add closure that renders the text into the result table
+	env = merge_tables(env,
+		{__liluat_output_function = function (text)
+			table.insert(result, text) end})
+
+	-- compile and run the lua code
+	local render_function = sandbox(t.code, t.name, env)
+	render_function()
+
 	return table.concat(result)
 end
 

--- a/liluat.lua
+++ b/liluat.lua
@@ -337,7 +337,7 @@ function liluat.compile(template, options, template_name, start_path)
 	options = initialise_options(options)
 	template_name = template_name or 'liluat.compile'
 
-	local output_function = "coroutine.yield"
+	local output_function = "__liluat_output_function"
 
 	-- split the template string into chunks
 	local lexed_template = parse(template, options, nil, nil, start_path)
@@ -430,6 +430,8 @@ end
 
 -- @return a coroutine function
 function liluat.render_coroutine(template, environment)
+	environment = merge_tables(environment, {__liluat_output_function = coroutine.yield})
+
 	return sandbox(template.code, template.name, environment)
 end
 

--- a/spec/index.html.template.lua
+++ b/spec/index.html.template.lua
@@ -1,12 +1,12 @@
 return {
 	code = [[
-coroutine.yield("<!DOCTYPE html>\
+__liluat_output_function("<!DOCTYPE html>\
 <html lang=\"en\">\
 <head>\
     <meta charset=\"UTF-8\">\
     <title>")
-coroutine.yield( title)
-coroutine.yield("</title>\
+__liluat_output_function( title)
+__liluat_output_function("</title>\
 </head>\
 <body>\
     <h1>This is the index page.</h1>\
@@ -14,12 +14,12 @@ coroutine.yield("</title>\
     <ol>\
 ")
 for i = 1, 5 do
-coroutine.yield("        <li>")
-coroutine.yield( i)
-coroutine.yield("</li>\
+__liluat_output_function("        <li>")
+__liluat_output_function( i)
+__liluat_output_function("</li>\
 ")
 end
-coroutine.yield("    </ol>\
+__liluat_output_function("    </ol>\
 </body>\
 </html>\
 ")]],

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -577,10 +577,10 @@ another line]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("a")
+__liluat_output_function("a")
 i = 0
-coroutine.yield( i)
-coroutine.yield("b")]]
+__liluat_output_function( i)
+__liluat_output_function("b")]]
 			}
 
 			assert.same(expected_output, liluat.compile(template))
@@ -591,7 +591,7 @@ coroutine.yield("b")]]
 			local template_name = "my template"
 			local expected_output = {
 				name = "my template",
-				code = 'coroutine.yield("a")'
+				code = '__liluat_output_function("a")'
 			}
 
 			assert.same(expected_output, liluat.compile(template, nil, template_name))
@@ -606,10 +606,10 @@ coroutine.yield("b")]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("a")
+__liluat_output_function("a")
 i = 0
-coroutine.yield( i)
-coroutine.yield("b")]]
+__liluat_output_function( i)
+__liluat_output_function("b")]]
 			}
 
 			assert.same(expected_output, liluat.compile(template, options))
@@ -630,13 +630,13 @@ some text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield( i)
+__liluat_output_function( i)
 end
  -- comment
-coroutine.yield("some text")]]
+__liluat_output_function("some text")]]
 			}
 
 			assert.same(expected_output, liluat.compile(template, options))
@@ -657,17 +657,17 @@ some text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 ")
-coroutine.yield( i)
+__liluat_output_function( i)
 end
-coroutine.yield("\
+__liluat_output_function("\
 ")
  -- comment
-coroutine.yield("\
+__liluat_output_function("\
 some text")]]
 			}
 
@@ -689,15 +689,15 @@ some text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
 ")
 end
  -- comment
-coroutine.yield("some text")]]
+__liluat_output_function("some text")]]
 			}
 
 			assert.same(expected_output, liluat.compile(template, options))
@@ -718,19 +718,19 @@ some text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 ")
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
 ")
 end
-coroutine.yield("\
+__liluat_output_function("\
 ")
  -- comment
-coroutine.yield("\
+__liluat_output_function("\
 some text")]]
 			}
 
@@ -754,17 +754,17 @@ some more text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 \
 ")
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
 ")
 end
-coroutine.yield("\
+__liluat_output_function("\
 some more text")]]
 			}
 
@@ -789,16 +789,16 @@ some more text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
  	")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 ")
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
  ")
 end
-coroutine.yield("\
+__liluat_output_function("\
 some more text")]]
 			}
 
@@ -823,16 +823,16 @@ some more text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 	")
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
 ")
 end
-coroutine.yield("\
+__liluat_output_function("\
 some more text")]]
 			}
 
@@ -857,16 +857,16 @@ some more text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
  	")
 for i = 1, 5 do
-coroutine.yield("\
+__liluat_output_function("\
 	")
-coroutine.yield( i)
-coroutine.yield("\
+__liluat_output_function( i)
+__liluat_output_function("\
  ")
 end
-coroutine.yield("\
+__liluat_output_function("\
 some more text")]]
 			}
 
@@ -900,26 +900,26 @@ more text]]
 			local expected_output = {
 				name = "liluat.compile",
 				code = [[
-coroutine.yield("some text\
+__liluat_output_function("some text\
 ")
-coroutine.yield( 1)
-coroutine.yield( 2)
-coroutine.yield( 3)
-coroutine.yield("\
+__liluat_output_function( 1)
+__liluat_output_function( 2)
+__liluat_output_function( 3)
+__liluat_output_function("\
 ")
-coroutine.yield( 4)
-coroutine.yield( 5)
-coroutine.yield(" \
+__liluat_output_function( 4)
+__liluat_output_function( 5)
+__liluat_output_function(" \
 \
 ")
-coroutine.yield( 6)
-coroutine.yield(" \
+__liluat_output_function( 6)
+__liluat_output_function(" \
 ")
-coroutine.yield( 7)
-coroutine.yield(" \
+__liluat_output_function( 7)
+__liluat_output_function(" \
 ")
-coroutine.yield( 8)
-coroutine.yield("more text")]]
+__liluat_output_function( 8)
+__liluat_output_function("more text")]]
 			}
 
 			assert.same(expected_output, liluat.compile(template, options))
@@ -959,7 +959,7 @@ coroutine.yield("more text")]]
 			local template = "  {{+code}}"
 
 			local expected_output = {
-				code = 'coroutine.yield("  ")\ncode',
+				code = '__liluat_output_function("  ")\ncode',
 				name = "liluat.compile"
 			}
 
@@ -993,7 +993,7 @@ coroutine.yield("more text")]]
 			}
 
 			local expected_output =  {
-				code = 'code\ncoroutine.yield("\\\n")',
+				code = 'code\n__liluat_output_function("\\\n")',
 				name = "liluat.compile"
 			}
 
@@ -1025,7 +1025,7 @@ coroutine.yield("more text")]]
 			}
 
 			local expected_output = {
-				code = 'coroutine.yield("  ")\ncode\ncoroutine.yield("\\\n")',
+				code = '__liluat_output_function("  ")\ncode\n__liluat_output_function("\\\n")',
 				name = "liluat.compile"
 			}
 

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -21,7 +21,7 @@
 -- IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --]]
 
-local liluat = require("liluat")
+local liluat = loadfile("liluat.lua")()
 
 describe("liluat", function ()
 	it("should return an empty string for empty templates", function ()

--- a/spec/runliluat_spec.lua
+++ b/spec/runliluat_spec.lua
@@ -21,7 +21,7 @@
 -- IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --]]
 
-local liluat = require("liluat")
+local liluat = loadfile("liluat.lua")()
 
 -- custom exec function that works across lua versions
 local function execute_command(command)


### PR DESCRIPTION
I still have to do benchmarks, but I'm quite confident, that the performance of rendering can be improved by not switching between coroutines all the time.

This pull request will replace `coroutine.yield` with `table.insert` when rendering with `liluat.render`. For `liluat.render_coroutine`, everything stays the same.
