### PR TITLE
Option to only reference template parameters without copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,13 @@ Same as `liluat.compile` but loads the template from a file. `template_name` is 
 * `filename`: File to load the template from.
 * `options`: A table containing different configuration options, see the [Options](#options) section.
 
-### liluat.render(compiled\_template, [values])
+### liluat.render(compiled\_template, [values], [options])
 Render a compiled template into a string, using the given values. This runs the compiled template in a sandbox with `values` added to it's environment.
 * `compiled_template`: This is the output of `liluat.compile`. Essentially Lua code with some meta data.
 * `values`: A Lua table containing any kind of values. This can even be functions or custom data types from C. These values are accessible inside the template.
+* `options`: A table containing different configuration options, see the [Options](#options) section. NOTE: Most of those options only change the behavior of `liluat.compile`.
 
-### liluat.render\_coroutine(compiled\_template, [values])
+### liluat.render\_coroutine(compiled\_template, [values], [options])
 Same as `liluat.render` but returns a function that can be run in a coroutine and will return one chunk of data at a time (so you can kind of "stream" the template rendering).
 
 ### liluat.inline(template, [options], [start\_path])
@@ -233,6 +234,7 @@ The following options can be passed via the `options` table:
 * `trim_right`: one of `"all"`, `"code"`, `"expression"` or `false` to disable. Default is `"code"`. See the section [Trimming](#trimming) for more information.
 * `trim_left`: one of `"all"`, `"code"`, `"expression"` or `false` to disable. Default is `"code"`. See the section [Trimming](#trimming) for more information.
 * `base_path`: Path that is used as base path for includes. If `nil` or `false`, all include paths are interpreted relative to the files path itself. Not that this doesn't influence absolute paths.
+* `reference`: If set to `true`, `liluat.render` will reference the environment in the sandbox instead of recursively copyiing it. This reduces part of the security of the sandbox, because values can now leak out of it. However, this option is useful if you pass in environments that use a lot of memory or contain reference cycles.
 
 ## Command line utility
 Liluat comes with a command line interface:

--- a/liluat.lua
+++ b/liluat.lua
@@ -79,14 +79,16 @@ end
 liluat.private.clone_table = clone_table
 
 -- recursively merge two tables, the second one has precedence
-local function merge_tables(a, b)
+-- if 'shallow' is set, the second table isn't copied recursively,
+-- its content is only referenced instead
+local function merge_tables(a, b, shallow)
 	a = a or {}
 	b = b or {}
 
 	local merged = clone_table(a)
 
 	for key, value in pairs(b) do
-		if type(value) == "table" then
+		if (type(value) == "table") and (not shallow) then
 			if a[key] then
 				merged[key] = merge_tables(a[key], value)
 			else

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -1401,5 +1401,29 @@ Runtime error in sandboxed code "code" in line 7:
 			assert.is_false(status)
 			assert.truthy(error_message:find(expected))
 		end)
+
+		it("should accept the 'reference' option", function ()
+			local template = "{{= tostring(table_reference)}}"
+			local parameters = {table_reference = {}}
+
+			local code = liluat.compile(template)
+
+			assert.equal(tostring(parameters.table_reference), liluat.render(code, parameters, {reference = true}))
+		end)
+	end)
+
+	describe("liluat.render_coroutine", function ()
+		it("should accept the 'reference' option", function ()
+			local template = "{{= tostring(table_reference)}}"
+			local parameters = {table_reference = {}}
+
+			local code = liluat.compile(template)
+
+			local thread = coroutine.wrap(liluat.render_coroutine(code, parameters, {reference = true}))
+
+			local rendered_string = thread()
+
+			assert.equal(tostring(parameters.table_reference), rendered_string)
+		end)
 	end)
 end)

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -239,6 +239,55 @@ Hello, &lt;world&gt;!
 			assert.same(expected_output, liluat.private.merge_tables(a, b))
 		end)
 
+		it("should merge the second table as reference, if 'reference' parameter is set", function ()
+			local a = {
+				a = 1,
+				b = 2,
+				c = {
+					d = 3,
+					e = {
+						f = 4
+					}
+				},
+				g = {
+					h = 5
+				}
+			}
+
+			local b = {
+				b = 3,
+				x = 5,
+				y = {
+					z = 4
+				},
+				c = {
+					j = 5
+				}
+			}
+
+			local expected_output = {
+			  a = 1,
+			  b = 3,
+			  c = {
+			    j = 5
+			  },
+			  g = {
+			    h = 5
+			  },
+			  x = 5,
+			  y = {
+			    z = 4
+			  }
+			}
+
+			local merged_table = liluat.private.merge_tables(a, b, true)
+
+			assert.same(expected_output, merged_table)
+
+			-- make sure it is actually referenced
+			assert.equal(b.c, merged_table.c)
+		end)
+
 		it("should merge nil tables", function ()
 			local a = {
 				a = 1


### PR DESCRIPTION
Currently, the template parameters passed to `liluat.render` or `liluat.render_coroutine` are recursively copied into a new table. Although this is useful for sandboxing, it causes problems if the environment uses a lot of memory.

This is also useful if you have reference cycles in your template parameters, which would otherwise be an infinite loop.

This pull request will introduce a new option `reference` so that the environment isn't copied but only referenced, thereby saving memory and the time to copy it.
