### PR TITLE
WIP: Support for copying environments with cycles and metatables

### DIFF
--- a/liluat.lua
+++ b/liluat.lua
@@ -102,6 +102,16 @@ local function bfs_clone(tab)
 			local copied_node = coloring[node]
 			copied_node[copied_key] = copied_value
 		end
+
+		local metatable = getmetatable(node)
+		if metatable then
+			if coloring[metatable] == nil then -- new node
+				coloring[metatable] = {}
+				table.insert(queue, metatable)
+			end
+
+			setmetatable(coloring[node], coloring[metatable])
+		end
 	until #queue == 0
 
 	return coloring[tab]

--- a/liluat.lua
+++ b/liluat.lua
@@ -122,22 +122,6 @@ local function bfs_clone(tab)
 end
 liluat.private.bfs_clone = bfs_clone
 
--- recursively copy a table
-local function clone_table(table)
-	local clone = {}
-
-	for key, value in pairs(table) do
-		if type(value) == "table" then
-			clone[key] = clone_table(value)
-		else
-			clone[key] = value
-		end
-	end
-
-	return clone
-end
-liluat.private.clone_table = clone_table
-
 -- recursively merge two tables, the second one has precedence
 -- if 'shallow' is set, the second table isn't copied recursively,
 -- its content is only referenced instead
@@ -145,14 +129,14 @@ local function merge_tables(a, b, shallow)
 	a = a or {}
 	b = b or {}
 
-	local merged = clone_table(a)
+	local merged = bfs_clone(a)
 
 	for key, value in pairs(b) do
 		if (type(value) == "table") and (not shallow) then
 			if a[key] then
 				merged[key] = merge_tables(a[key], value)
 			else
-				merged[key] = clone_table(value)
+				merged[key] = bfs_clone(value)
 			end
 		else
 			merged[key] = value

--- a/liluat.lua
+++ b/liluat.lua
@@ -68,6 +68,10 @@ local function bfs_clone(tab)
 	local queue = {}
 	local coloring = {}
 
+	local function pairs(table)
+		return next, table
+	end
+
 	-- color the table
 	coloring[tab] = {}
 	-- queue up the table

--- a/liluat.lua
+++ b/liluat.lua
@@ -62,6 +62,52 @@ local function escape_pattern(text)
 end
 liluat.private.escape_pattern = escape_pattern
 
+-- make a deep copy of a table using breadth first search.
+-- supports cycles
+local function bfs_clone(tab)
+	local queue = {}
+	local coloring = {}
+
+	-- color the table
+	coloring[tab] = {}
+	-- queue up the table
+	table.insert(queue, tab)
+
+	local node = nil
+	repeat
+		node = table.remove(queue, 1)
+
+		for key,value in pairs(node) do
+			if coloring[key] == nil then -- new node
+				if type(key) == "table" then
+					coloring[key] = {}
+					table.insert(queue, key)
+				else
+					coloring[key] = key
+				end
+			end
+
+			if coloring[value] == nil then -- new node
+				if type(value) == "table" then
+					coloring[value] = {}
+					table.insert(queue, value)
+				else
+					coloring[value] = value
+				end
+			end
+
+			-- put key and value in the copy
+			local copied_key = coloring[key]
+			local copied_value = coloring[value]
+			local copied_node = coloring[node]
+			copied_node[copied_key] = copied_value
+		end
+	until #queue == 0
+
+	return coloring[tab]
+end
+liluat.private.bfs_clone = bfs_clone
+
 -- recursively copy a table
 local function clone_table(table)
 	local clone = {}

--- a/liluat.lua
+++ b/liluat.lua
@@ -107,14 +107,14 @@ local function bfs_clone(tab)
 			rawset(copied_node, copied_key, copied_value)
 		end
 
-		local metatable = getmetatable(node)
+		local metatable = debug.getmetatable(node)
 		if metatable then
 			if coloring[metatable] == nil then -- new node
 				coloring[metatable] = {}
 				table.insert(queue, metatable)
 			end
 
-			setmetatable(coloring[node], coloring[metatable])
+			debug.setmetatable(coloring[node], coloring[metatable])
 		end
 	until #queue == 0
 

--- a/liluat.lua
+++ b/liluat.lua
@@ -104,7 +104,7 @@ local function bfs_clone(tab)
 			local copied_key = coloring[key]
 			local copied_value = coloring[value]
 			local copied_node = coloring[node]
-			copied_node[copied_key] = copied_value
+			rawset(copied_node, copied_key, copied_value)
 		end
 
 		local metatable = getmetatable(node)

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -284,6 +284,29 @@ Hello, &lt;world&gt;!
 			assert.equal(table.a, clone.a)
 			assert.equal(pairs, getmetatable(clone).__pairs)
 		end)
+
+		it("should clone tables with __index and __newindex metamethods", function ()
+			local index = function (table, key, value)
+				return true
+			end
+
+			local newindex = function (table, key, value)
+				rawset(table, key, false)
+			end
+
+			local table = {a = 1}
+			local metatable = {__index = index, __newindex = newindex}
+			setmetatable(table, metatable)
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.equal(table.a, clone.a)
+			assert.not_equal(getmetatable(table), getmetatable(clone))
+			assert.is_true(clone.something)
+			clone.bla = 4
+			assert.is_false(clone.bla)
+		end)
 	end)
 
 	describe("merge_tables", function ()

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -409,6 +409,25 @@ Hello, &lt;world&gt;!
 			assert.same({a = 1}, liluat.private.merge_tables(a, nil))
 			assert.same({}, liluat.private.merge_tables(nil, nil))
 		end)
+
+		pending("should merge a table with cycles", function ()
+			local table = {a = 1}
+
+			local c = {c = true}
+			local b = {c = c, b = false}
+			local a = {b = b}
+			c.a = a
+
+			local merged = liluat.private.merge_tables(table, a)
+
+			assert.not_equal(a1, merged)
+			assert.not_equal(a2, merged)
+			assert.equal(merged, merged.b.c.a)
+
+		end)
+
+		pending("should join common subtables when merging", function ()
+		end)
 	end)
 
 	describe("escape_pattern", function ()

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -224,6 +224,50 @@ Hello, &lt;world&gt;!
 			assert.equal(clone[clone], clone)
 			assert.equal(clone.b, clone)
 		end)
+
+		it("should clone a metatable", function ()
+			local table = {table = true}
+			local metatable = {metatable = true}
+			setmetatable(table, metatable)
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.is_true(clone.table)
+			assert.is_table(getmetatable(clone))
+			assert.not_equal(getmetatable(clone), getmetatable(table))
+			assert.is_true(getmetatable(clone).metatable)
+		end)
+
+		it("should clone a table and it's metatables", function ()
+			local a = {test = true}
+			local b = {test = false}
+			setmetatable(a, b)
+			setmetatable(b, a)
+
+			local table = {
+				[4] = 5,
+				a = a,
+				b = b,
+				[a] = a,
+				[b] = a
+			}
+
+			table[table] = table
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.not_equal(table.a, clone.a)
+			assert.not_equal(table.b, clone.b)
+			assert.equal(5, clone[4])
+			assert.not_equal(clone.a, clone.b)
+			assert.equal(clone.a, clone[clone.a])
+			assert.equal(clone.a, clone[clone.b])
+			assert.equal(clone, clone[clone])
+			assert.equal(clone.a, getmetatable(clone.b))
+			assert.equal(clone.b, getmetatable(clone.a))
+		end)
 	end)
 
 	describe("merge_tables", function ()

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -268,6 +268,22 @@ Hello, &lt;world&gt;!
 			assert.equal(clone.a, getmetatable(clone.b))
 			assert.equal(clone.b, getmetatable(clone.a))
 		end)
+
+		it("should clone tables with __pairs in their metatable", function ()
+			local pairs = function ()
+				return nil
+			end
+
+			local table = {a = 1}
+			local metatable = {__pairs = pairs}
+			setmetatable(table, metatable)
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.equal(table.a, clone.a)
+			assert.equal(pairs, getmetatable(clone).__pairs)
+		end)
 	end)
 
 	describe("merge_tables", function ()

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -190,6 +190,42 @@ Hello, &lt;world&gt;!
 		end)
 	end)
 
+	describe("bfs_clone", function ()
+		it("should clone a table", function ()
+			local table = {
+				a = {
+					b = 1,
+					c = {
+						d = 2
+					}
+				},
+				e = 3
+			}
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.same(table, clone)
+			assert.not_equal(table, clone)
+			assert.not_equal(table.a, clone.a)
+			assert.not_equal(table.a.c, clone.a.c)
+		end)
+
+		it("should clone a table with cycles", function ()
+			local table = {
+				a = 1
+			}
+			table.b = table
+			table[table] = table
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.equal(table.a, clone.a)
+			assert.equal(clone[clone], clone)
+			assert.equal(clone.b, clone)
+		end)
+	end)
+
 	describe("merge_tables", function ()
 		it("should merge two tables", function ()
 			local a = {

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -169,27 +169,6 @@ Hello, &lt;world&gt;!
 		end)
 	end)
 
-	describe("clone_table", function ()
-		it("should clone a table", function ()
-			local table = {
-				a = {
-					b = 1,
-					c = {
-						d = 2
-					}
-				},
-				e = 3
-			}
-
-			local clone = liluat.private.clone_table(table)
-
-			assert.same(table, clone)
-			assert.not_equal(table, clone)
-			assert.not_equal(table.a, clone.a)
-			assert.not_equal(table.a.c, clone.a.c)
-		end)
-	end)
-
 	describe("bfs_clone", function ()
 		it("should clone a table", function ()
 			local table = {

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -307,6 +307,20 @@ Hello, &lt;world&gt;!
 			clone.bla = 4
 			assert.is_false(clone.bla)
 		end)
+
+		it("should clone tables with __metatable in their metatable", function ()
+			local table = {}
+			local metatable = {__metatable = false}
+			setmetatable(table, metatable)
+
+			local clone = liluat.private.bfs_clone(table)
+
+			assert.not_equal(table, clone)
+			assert.is_false(getmetatable(clone))
+			assert.not_equal(debug.getmetatable(table), debug.getmetatable(clone))
+			assert.truthy(debug.getmetatable(clone))
+			assert.is_false(debug.getmetatable(clone).__metatable)
+		end)
 	end)
 
 	describe("merge_tables", function ()


### PR DESCRIPTION
This uses breadth first search for copying in order to make it possible to clone tables with reference cycles and metatables.

Fixes #10 and #9 

This will fix object oriented interfaces inside the sandbox.

This means that the only remaining use cases for the `reference` option are:
1. When the table uses too much memory.
2. When it takes too much time to copy the table.
