### PR TITLE
liluat.private.clone_table: added support for cloning cyclical tables…

### DIFF
--- a/liluat.lua
+++ b/liluat.lua
@@ -63,19 +63,21 @@ end
 liluat.private.escape_pattern = escape_pattern
 
 -- recursively copy a table
-local function clone_table(table)
-	local clone = {}
+-- adapted from https://gist.github.com/tylerneylon/81333721109155b2d244, copy3() recursive function
+local function clone_table(obj, seen)
+  -- Handle non-tables and previously-seen tables.
+  if type(obj) ~= 'table' then return obj end
+  if seen and seen[obj] then return seen[obj] end
 
-	for key, value in pairs(table) do
-		if type(value) == "table" then
-			clone[key] = clone_table(value)
-		else
-			clone[key] = value
-		end
-	end
-
-	return clone
+  -- New table; mark it as seen an copy recursively.
+  local s = seen or {}
+  local res = {}
+  s[obj] = res
+  setmetatable(res, clone_table(getmetatable(obj), s))
+  for k, v in pairs(obj) do res[clone_table(k, s)] = clone_table(v, s) end
+  return res
 end
+
 liluat.private.clone_table = clone_table
 
 -- recursively merge two tables, the second one has precedence

--- a/spec/liluat_spec.lua
+++ b/spec/liluat_spec.lua
@@ -188,6 +188,31 @@ Hello, &lt;world&gt;!
 			assert.not_equal(table.a, clone.a)
 			assert.not_equal(table.a.c, clone.a.c)
 		end)
+		it("should clone a self-referencing/cyclical table (with metatable)", function ()
+			local table = {
+				a = {
+					b = 1,
+					c = {
+						d = 2
+					}
+				},
+				e = 3
+			}
+			table.f = table
+			table.a.c.g = table.a
+			setmetatable(table, table)
+
+			local clone = liluat.private.clone_table(table)
+
+			assert.same(table, clone)
+			assert.same(getmetatable(table), getmetatable(clone))
+			assert.not_equal(table, clone)
+			assert.not_equal(table.a, clone.a)
+			assert.not_equal(table.a.c, clone.a.c)
+			assert.not_equal(table.f, clone.f)
+			assert.not_equal(table.a.c.g, clone.a.c.g)
+			assert.not_equal(getmetatable(table).a.c.g, getmetatable(clone).a.c.g)
+		end)
 	end)
 
 	describe("merge_tables", function ()


### PR DESCRIPTION
… (and their metatables). Fixes stack overflow error due to recursion.